### PR TITLE
Keep the original publish date when re-publishing a post

### DIFF
--- a/src/Lazy.Blog.Domain/Entities/Post.cs
+++ b/src/Lazy.Blog.Domain/Entities/Post.cs
@@ -170,6 +170,14 @@ public sealed class Post : AggregateRoot, IAuditableEntity
     public void Publish()
     {
         IsPublished = true;
-        PublishedOnUtc = DateTime.UtcNow;
+
+        // Only stamp the publish date on the FIRST publish — re-publishing an
+        // already-dated post (after a Hide) must keep its original date so it
+        // returns to its place in the feed instead of jumping to "latest drop".
+        // Mirrors the Update() guard above.
+        if (PublishedOnUtc is null)
+        {
+            PublishedOnUtc = DateTime.UtcNow;
+        }
     }
 }


### PR DESCRIPTION
Post.Publish() unconditionally set `PublishedOnUtc = DateTime.UtcNow` on every call. Unpublishing a post (Hide) and publishing it again therefore stamped a brand-new publish date, which sent the post to the top of every feed — they order by `OrderByDescending(p => p.PublishedOnUtc)` — as if it were the latest drop, even though the date shown on the card (CreatedOnUtc) was unchanged. Reported as "unpublish → publish makes the post jump to latest drop".

Make Publish() idempotent: only stamp `PublishedOnUtc` on the FIRST publish (while it is still null), mirroring the existing guard already used in Post.Update() (`if (isPublished && PublishedOnUtc is null)`). Re-publishing after a Hide now preserves the original publish date, so the post returns to its chronological place in the feed instead of becoming the latest drop.

File: src/Lazy.Blog.Domain/Entities/Post.cs