### PR TITLE
feat(posts): add post rating-over-time history endpoint

### DIFF
--- a/src/Lazy.Blog.Application/Posts/GetPostRatingHistory/GetPostRatingHistoryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostRatingHistory/GetPostRatingHistoryHandler.cs
@@ -1,0 +1,100 @@
+using Lazy.Application.Abstractions.Messaging;
+using Lazy.Domain.Entities;
+using Lazy.Domain.Errors;
+using Lazy.Domain.Repositories;
+using Lazy.Domain.Shared;
+using Lazy.Domain.ValueObjects.Post;
+
+namespace Lazy.Application.Posts.GetPostRatingHistory;
+
+public class GetPostRatingHistoryHandler(
+    IPostRepository postRepository,
+    IPostVoteRepository postVoteRepository)
+    : IQueryHandler<GetPostRatingHistoryQuery, PostRatingHistoryResponse>
+{
+    private const int MaxPoints = 12;
+
+    public async Task<Result<PostRatingHistoryResponse>> Handle(
+        GetPostRatingHistoryQuery request,
+        CancellationToken ct)
+    {
+        Result<Slug> slugResult = Slug.Create(request.Slug);
+
+        if (slugResult.IsFailure)
+        {
+            return Result.Failure<PostRatingHistoryResponse>(slugResult.Error);
+        }
+
+        Post? post = await postRepository.GetBySlugAsync(slugResult.Value, ct);
+
+        if (post is null)
+        {
+            return Result.Failure<PostRatingHistoryResponse>(
+                DomainErrors.Post.SlugNotFound(slugResult.Value));
+        }
+
+        List<VoteEntry> votes = postVoteRepository
+            .GetPostVotesByPostId(post.Id, ct)
+            .Select(pv => new VoteEntry(
+                pv.CreatedOnUtc,
+                pv.VoteDirection == VoteDirection.Up ? 1 : -1))
+            .ToList();
+
+        IReadOnlyList<PostRatingHistoryPoint> series =
+            BuildSeries(votes, post.Rating, post.CreatedOnUtc);
+
+        return new PostRatingHistoryResponse(
+            post.Id,
+            post.Slug.Value,
+            post.Rating,
+            series);
+    }
+
+    private static IReadOnlyList<PostRatingHistoryPoint> BuildSeries(
+        IReadOnlyList<VoteEntry> votes,
+        int currentRating,
+        DateTime postCreatedOnUtc)
+    {
+        if (votes.Count == 0)
+        {
+            return [new PostRatingHistoryPoint(postCreatedOnUtc, currentRating)];
+        }
+
+        var cumulative = new List<PostRatingHistoryPoint>(votes.Count);
+        int running = 0;
+
+        foreach (VoteEntry vote in votes)
+        {
+            running += vote.Delta;
+            cumulative.Add(new PostRatingHistoryPoint(vote.CreatedOnUtc, running));
+        }
+
+        List<PostRatingHistoryPoint> sampled = Sample(cumulative, MaxPoints);
+
+        sampled[^1] = sampled[^1] with { CumulativeRating = currentRating };
+
+        return sampled;
+    }
+
+    private static List<PostRatingHistoryPoint> Sample(
+        IReadOnlyList<PostRatingHistoryPoint> points,
+        int maxPoints)
+    {
+        if (points.Count <= maxPoints)
+        {
+            return [.. points];
+        }
+
+        var sampled = new List<PostRatingHistoryPoint>(maxPoints);
+
+        for (int i = 0; i < maxPoints; i++)
+        {
+            int index = (int)((long)i * (points.Count - 1) / (maxPoints - 1));
+            sampled.Add(points[index]);
+        }
+
+        return sampled;
+    }
+
+    private readonly record struct VoteEntry(DateTime CreatedOnUtc, int Delta);
+}

--- a/src/Lazy.Blog.Application/Posts/GetPostRatingHistory/GetPostRatingHistoryQuery.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostRatingHistory/GetPostRatingHistoryQuery.cs
@@ -1,0 +1,5 @@
+using Lazy.Application.Abstractions.Messaging;
+
+namespace Lazy.Application.Posts.GetPostRatingHistory;
+
+public record GetPostRatingHistoryQuery(string Slug) : IQuery<PostRatingHistoryResponse>;

--- a/src/Lazy.Blog.Application/Posts/GetPostRatingHistory/PostRatingHistoryResponse.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostRatingHistory/PostRatingHistoryResponse.cs
@@ -1,0 +1,11 @@
+namespace Lazy.Application.Posts.GetPostRatingHistory;
+
+public record PostRatingHistoryResponse(
+    Guid PostId,
+    string Slug,
+    int Rating,
+    IReadOnlyList<PostRatingHistoryPoint> Series);
+
+public record PostRatingHistoryPoint(
+    DateTime TimestampUtc,
+    int CumulativeRating);

--- a/src/Lazy.Blog.Domain/Repositories/IPostVoteRepository.cs
+++ b/src/Lazy.Blog.Domain/Repositories/IPostVoteRepository.cs
@@ -9,5 +9,7 @@ public interface IPostVoteRepository
 
     Task<PostVote?> GetPostVoteForUserIdAsync(Guid userId, Guid postId, CancellationToken ct);
 
+    IQueryable<PostVote> GetPostVotesByPostId(Guid postId, CancellationToken ct);
+
     void Update(PostVote vote);
 }

--- a/src/Lazy.Blog.Persistence/Repositories/PostVoteRepository.cs
+++ b/src/Lazy.Blog.Persistence/Repositories/PostVoteRepository.cs
@@ -31,6 +31,12 @@ public class PostVoteRepository : IPostVoteRepository
             .SingleOrDefaultAsync(p => p.UserId == userId, ct);
     }
 
+    public IQueryable<PostVote> GetPostVotesByPostId(Guid postId, CancellationToken ct) =>
+        _dbContext.Set<PostVote>()
+            .AsNoTracking()
+            .Where(pv => pv.PostId == postId)
+            .OrderBy(pv => pv.CreatedOnUtc);
+
     public void Update(PostVote vote) =>
         _dbContext.Set<PostVote>().Update(vote);
 }

--- a/src/Lazy.Blog.Presentation/Controllers/PostsController.cs
+++ b/src/Lazy.Blog.Presentation/Controllers/PostsController.cs
@@ -9,6 +9,7 @@ using Lazy.Application.Posts.GetPostBySlug;
 using Lazy.Application.Posts.GetPostByTag;
 using Lazy.Application.Posts.GetPostByUserId;
 using Lazy.Application.Posts.GetPostByUserName;
+using Lazy.Application.Posts.GetPostRatingHistory;
 using Lazy.Application.Posts.GetPublishedPosts;
 using Lazy.Application.Posts.HidePost;
 using Lazy.Application.Posts.PublishPost;
@@ -112,6 +113,19 @@ public class PostsController : BaseJwtController
 
         return response.IsSuccess ? Ok(response.Value) : NotFound(response.Error);
 
+    }
+
+    [AllowAnonymous]
+    [HttpGet("{slug}/rating-history", Name = nameof(GetPostRatingHistory))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PostRatingHistoryResponse))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPostRatingHistory(string slug, CancellationToken ct)
+    {
+        var query = new GetPostRatingHistoryQuery(slug);
+
+        Result<PostRatingHistoryResponse> response = await Sender.Send(query, ct);
+
+        return response.IsSuccess ? Ok(response.Value) : NotFound(response.Error);
     }
 
     [HttpPost(Name = nameof(CreatePost))]


### PR DESCRIPTION
Adds a public read endpoint that returns a post's cumulative net rating sampled over the timeline of its votes, so the frontend post page can render the "RATING" sparkline with real data instead of the current stub.

Endpoint
  GET api/posts/{slug}/rating-history  [AllowAnonymous]
  200 -> PostRatingHistoryResponse, 404 -> Post.NotFound

Response contract (PostRatingHistoryResponse)
  PostId   : Guid
  Slug     : string
  Rating   : int                         current net rating (source of truth)
  Series   : PostRatingHistoryPoint[]     ordered oldest -> newest
             { TimestampUtc: DateTime, CumulativeRating: int }
  The last point's CumulativeRating is pinned to Rating. When a post has no
  votes the series is a single point at the current rating, stamped with the
  post's CreatedOnUtc. The series is capped at 12 points via even sampling
  across the vote timeline so it always renders as a clean, bounded sparkline.

Implementation
  - Application/Posts/GetPostRatingHistory/: query (by slug, consistent with GetPostBySlug), primary-constructor handler, response records.
  - IPostVoteRepository.GetPostVotesByPostId -> IQueryable<PostVote> ordered by CreatedOnUtc; materialized synchronously in the handler (matches the existing IQueryable + .ToList() pattern, keeping EF Core out of Application).
  - PostsController.GetPostRatingHistory dispatches and maps IsSuccess.

Caveat: vote rows are a current snapshot, not an append-only log — the AddPostVote handler deletes/updates a user's row on flip/toggle — so the series reflects the votes that currently stand, with the final point pinned to the authoritative denormalized Post.Rating.