### PR TITLE
fix(posts): implement standard toggle voting

### DIFF
--- a/src/Lazy.Blog.Application/Posts/AddPostVote/AddPostVoteCommandHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/AddPostVote/AddPostVoteCommandHandler.cs
@@ -41,23 +41,20 @@ public class AddPostVoteCommandHandler : ICommandHandler<AddPostVoteCommand>
 
         if (postVote is not null)
         {
-            if (postVote.VoteDirection != request.Direction)
+            postVote.Post.Unvote(postVote.VoteDirection);
+
+            if (postVote.VoteDirection == request.Direction)
             {
-                postVote.Post.Vote(request.Direction);
-                _postRepository.Update(postVote.Post);
                 _postVoteRepository.Delete(postVote);
-
-                await _unitOfWork.SaveChangesAsync(ct);
-                return Result.Success();
             }
-
-            bool successUpdate = postVote.Update(request.Direction);
-            if (!successUpdate)
+            else
             {
-                return Result.Failure(DomainErrors.Post.PostAlreadyVoted);
+                postVote.ChangeDirection(request.Direction);
+                postVote.Post.Vote(request.Direction);
+                _postVoteRepository.Update(postVote);
             }
 
-            _postVoteRepository.Update(postVote);
+            _postRepository.Update(postVote.Post);
         }
         else
         {

--- a/src/Lazy.Blog.Domain/Entities/Post.cs
+++ b/src/Lazy.Blog.Domain/Entities/Post.cs
@@ -162,6 +162,21 @@ public sealed class Post : AggregateRoot, IAuditableEntity
         }
     }
 
+    public void Unvote(VoteDirection postVoteVoteDirection)
+    {
+        switch (postVoteVoteDirection)
+        {
+            case VoteDirection.Up:
+                DownVote();
+                break;
+            case VoteDirection.Down:
+                UpVote();
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(postVoteVoteDirection), postVoteVoteDirection, null);
+        }
+    }
+
     public void Hide()
     {
         IsPublished = false;

--- a/src/Lazy.Blog.Domain/Entities/PostVote.cs
+++ b/src/Lazy.Blog.Domain/Entities/PostVote.cs
@@ -38,17 +38,8 @@ public class PostVote : Entity, IAuditableEntity
         return postVote;
     }
 
-    public bool Update(VoteDirection direction)
+    public void ChangeDirection(VoteDirection direction)
     {
-        if (VoteDirection == direction)
-        {
-            return false;
-        }
-        
-        Post.Vote(direction);
-
         VoteDirection = direction;
-
-        return true;
     }
 }


### PR DESCRIPTION
Reworks the post-vote flow so that a vote command behaves like a standard toggle, and fixes the denormalized Post.Rating counter so it always equals (#Up - #Down).

Previously, voting the same direction twice returned a Post.PostAlreadyVoted failure (treated as an error instead of an un-vote), and the "switch direction" path applied only the new vote's +/-1 without reverting the old vote's contribution, so a switch moved Rating by +/-1 instead of +/-2.

Behaviour now:
- No existing vote -> create vote, Rating +1 (Up) / -1 (Down).
- Same direction again -> remove the vote row, Rating reverts toward 0.
- Different direction -> switch the single vote row, Rating swings by 2 (revert old contribution + apply new one).

Changes:
- Post.Unvote(VoteDirection): reverts a vote's rating contribution (Up -> Rating--, Down -> Rating++), the inverse of Post.Vote.
- AddPostVoteCommandHandler: for an existing vote, always Unvote the old direction first, then delete the row (same direction) or set the new direction and re-Vote (switch). Removes the PostAlreadyVoted failure path. No-existing-vote branch unchanged.
- PostVote.Update -> PostVote.ChangeDirection: sets VoteDirection only; rating is now owned by the handler via Post.Vote/Post.Unvote, so the entity no longer mutates Rating as a side effect of changing direction.