### PR TITLE
feat: post vote counts

### DIFF
--- a/src/Lazy.Blog.Api/Extensions/OpenApi.cs
+++ b/src/Lazy.Blog.Api/Extensions/OpenApi.cs
@@ -1,9 +1,22 @@
-﻿namespace Lazy.Blog.Api.Extensions;
+using Microsoft.OpenApi;
+
+namespace Lazy.Blog.Api.Extensions;
 
 public static class OpenApi
 {
     public static void AddOpenApi(this IServiceCollection services)
     {
-        OpenApiServiceCollectionExtensions.AddOpenApi(services);
+        OpenApiServiceCollectionExtensions.AddOpenApi(services, "v1", options =>
+            options.AddSchemaTransformer((schema, _, _) =>
+            {
+                if (schema.Type is { } type
+                    && type.HasFlag(JsonSchemaType.Integer)
+                    && type.HasFlag(JsonSchemaType.String))
+                {
+                    schema.Type = type & ~JsonSchemaType.String;
+                }
+
+                return Task.CompletedTask;
+            }));
     }
 }

--- a/src/Lazy.Blog.Application/Posts/GetPostRatingHistory/GetPostRatingHistoryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostRatingHistory/GetPostRatingHistoryHandler.cs
@@ -40,6 +40,9 @@ public class GetPostRatingHistoryHandler(
                 pv.VoteDirection == VoteDirection.Up ? 1 : -1))
             .ToList();
 
+        int upVotes = votes.Count(v => v.Delta > 0);
+        int downVotes = votes.Count(v => v.Delta < 0);
+
         IReadOnlyList<PostRatingHistoryPoint> series =
             BuildSeries(votes, post.Rating, post.CreatedOnUtc);
 
@@ -47,6 +50,8 @@ public class GetPostRatingHistoryHandler(
             post.Id,
             post.Slug.Value,
             post.Rating,
+            upVotes,
+            downVotes,
             series);
     }
 

--- a/src/Lazy.Blog.Application/Posts/GetPostRatingHistory/PostRatingHistoryResponse.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostRatingHistory/PostRatingHistoryResponse.cs
@@ -4,6 +4,8 @@ public record PostRatingHistoryResponse(
     Guid PostId,
     string Slug,
     int Rating,
+    int UpVotes,
+    int DownVotes,
     IReadOnlyList<PostRatingHistoryPoint> Series);
 
 public record PostRatingHistoryPoint(


### PR DESCRIPTION
## What

  Two backend changes that unblock the frontend post-stats wiring (rating chart + like/dislike counts).

  ### 1. Up/down vote counts on the rating-history response

  `PostRatingHistoryResponse` now carries `UpVotes` / `DownVotes` (int), counted from the post's vote rows in `GetPostRatingHistoryHandler` (no extra query — it already materialises the rows for the series). `UpVotes - DownVotes` stays equal to the net `Rating`. Lets the post page show like/dislike totals
  separately instead of stubbing them.
  
  ### 2. int64 → plain `integer` in the OpenAPI document

  .NET 10 emits `long` as `type: ["integer", "string"]` (JS-precision-safe). The frontend's `typescript-fetch` generator can't model that union and produces empty interfaces (`DisplayPostResponseViews {}`, `GetAllPostsOffsetParameter {}`), so `gen:api` breaks the build. Added an `IOpenApiSchemaTransformer` (in
  `OpenApi.cs`) that drops the `string` member from any `integer | string` union → int64 fields/params (`Views`, `Rating`, the `offset` query param, the new counts) emit as plain `integer` → the generator produces `number`. The string enum `voteDirection` is untouched.

  ## Notes

  - No migration (no schema change). `dotnet build` clean.
  - After deploy, the frontend regenerates the client (`gen:api`, now clean) and wires the rating chart + real up/down counts into the post vote band.