### PR TITLE
feat: profile and home stats

### DIFF
--- a/src/Lazy.Blog.Api/Program.cs
+++ b/src/Lazy.Blog.Api/Program.cs
@@ -92,11 +92,18 @@ try
 
     builder.Services.AddProblemDetails();
 
-    builder.Services.AddDbContext<LazyBlogDbContext>(
+    builder.Services.AddDbContextFactory<LazyBlogDbContext>(
         (sp, optionsBuilder) =>
         {
             optionsBuilder.UseSqlServer(connectionString);
         });
+
+    builder.Services.AddDbContext<LazyBlogDbContext>(
+        (sp, optionsBuilder) =>
+        {
+            optionsBuilder.UseSqlServer(connectionString);
+        },
+        optionsLifetime: ServiceLifetime.Singleton);
 
     builder.Services.AddDefaultIdentity<User>()
         .AddRoles<Role>()

--- a/src/Lazy.Blog.Application/Posts/Extensions/PostMapper.cs
+++ b/src/Lazy.Blog.Application/Posts/Extensions/PostMapper.cs
@@ -1,7 +1,9 @@
+using Lazy.Application.Posts.GetHomeStats;
 using Lazy.Application.Posts.GetPostByUserId;
 using Lazy.Application.Posts.GetPublishedPosts;
 using Lazy.Application.Posts.Models;
 using Lazy.Application.Tags.SearchTag;
+using Lazy.Application.Users.GetUserById;
 using Lazy.Domain.Entities;
 using Lazy.Domain.Repositories;
 
@@ -62,4 +64,10 @@ public static class PostMapper
         monthlyPostCounts
             .Select(m => new PostsPerMonth(m.Year, m.Month, m.Count))
             .ToList();
+
+    public static MostActiveUserResponse ToMostActiveUserResponse(this MonthlyTopAuthor topAuthor) =>
+        new(new UserResponse(topAuthor.User), topAuthor.PostCount, topAuthor.NetRating);
+
+    public static TopPostResponse ToTopPostResponse(this MonthlyTopPost topPost) =>
+        new(topPost.Title, topPost.Slug, topPost.UserName, topPost.Views, topPost.NetRating);
 }

--- a/src/Lazy.Blog.Application/Posts/Extensions/PostMapper.cs
+++ b/src/Lazy.Blog.Application/Posts/Extensions/PostMapper.cs
@@ -1,7 +1,9 @@
+using Lazy.Application.Posts.GetPostByUserId;
 using Lazy.Application.Posts.GetPublishedPosts;
 using Lazy.Application.Posts.Models;
 using Lazy.Application.Tags.SearchTag;
 using Lazy.Domain.Entities;
+using Lazy.Domain.Repositories;
 
 namespace Lazy.Application.Posts.Extensions;
 
@@ -52,7 +54,12 @@ public static class PostMapper
                     p.Tags.Select(t => new TagPostResponse(t.Id, t.Value)).ToList(),
                     p.CreatedOnUtc))
             .ToList();
-        
+
         return result;
     }
+
+    public static IReadOnlyList<PostsPerMonth> ToPostsPerMonth(this IReadOnlyList<MonthlyPostCount> monthlyPostCounts) =>
+        monthlyPostCounts
+            .Select(m => new PostsPerMonth(m.Year, m.Month, m.Count))
+            .ToList();
 }

--- a/src/Lazy.Blog.Application/Posts/GetHomeStats/GetHomeStatsQuery.cs
+++ b/src/Lazy.Blog.Application/Posts/GetHomeStats/GetHomeStatsQuery.cs
@@ -1,0 +1,5 @@
+using Lazy.Application.Abstractions.Messaging;
+
+namespace Lazy.Application.Posts.GetHomeStats;
+
+public record GetHomeStatsQuery : IQuery<HomeStatsResponse>;

--- a/src/Lazy.Blog.Application/Posts/GetHomeStats/GetHomeStatsQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetHomeStats/GetHomeStatsQueryHandler.cs
@@ -1,0 +1,25 @@
+using Lazy.Application.Abstractions.Messaging;
+using Lazy.Application.Posts.Extensions;
+using Lazy.Domain.Repositories;
+using Lazy.Domain.Shared;
+
+namespace Lazy.Application.Posts.GetHomeStats;
+
+public class GetHomeStatsQueryHandler(IPostRepository postRepository)
+    : IQueryHandler<GetHomeStatsQuery, HomeStatsResponse>
+{
+    public async Task<Result<HomeStatsResponse>> Handle(GetHomeStatsQuery request, CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var monthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        MonthlyTopAuthor? topAuthor = await postRepository.GetMostActiveAuthorAsync(monthStart, now, ct);
+        MonthlyTopPost? topPost = await postRepository.GetMostViewedPostAsync(monthStart, now, ct);
+
+        var response = new HomeStatsResponse(
+            topAuthor?.ToMostActiveUserResponse(),
+            topPost?.ToTopPostResponse());
+
+        return response;
+    }
+}

--- a/src/Lazy.Blog.Application/Posts/GetHomeStats/GetHomeStatsQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetHomeStats/GetHomeStatsQueryHandler.cs
@@ -19,13 +19,13 @@ public class GetHomeStatsQueryHandler(IPostRepository postRepository)
 
         await Task.WhenAll(topAuthorTask, topPostTask, postsByMonthTask);
 
-        MonthlyTopAuthor? topAuthor = await topAuthorTask;
-        MonthlyTopPost? topPost = await topPostTask;
+        MonthlyTopAuthor? topAuthor = topAuthorTask.Result;
+        MonthlyTopPost? topPost = topPostTask.Result;
 
         var response = new HomeStatsResponse(
             topAuthor?.ToMostActiveUserResponse(),
             topPost?.ToTopPostResponse(),
-            (await postsByMonthTask).ToPostsPerMonth());
+            postsByMonthTask.Result.ToPostsPerMonth());
 
         return response;
     }

--- a/src/Lazy.Blog.Application/Posts/GetHomeStats/GetHomeStatsQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetHomeStats/GetHomeStatsQueryHandler.cs
@@ -13,14 +13,19 @@ public class GetHomeStatsQueryHandler(IPostRepository postRepository)
         var now = DateTime.UtcNow;
         var monthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        MonthlyTopAuthor? topAuthor = await postRepository.GetMostActiveAuthorAsync(monthStart, now, ct);
-        MonthlyTopPost? topPost = await postRepository.GetMostViewedPostAsync(monthStart, now, ct);
-        IReadOnlyList<MonthlyPostCount> postsByMonth = await postRepository.GetMonthlyPostCountsAsync(ct);
+        Task<MonthlyTopAuthor?> topAuthorTask = postRepository.GetMostActiveAuthorAsync(monthStart, now, ct);
+        Task<MonthlyTopPost?> topPostTask = postRepository.GetMostViewedPostAsync(monthStart, now, ct);
+        Task<IReadOnlyList<MonthlyPostCount>> postsByMonthTask = postRepository.GetMonthlyPostCountsAsync(ct);
+
+        await Task.WhenAll(topAuthorTask, topPostTask, postsByMonthTask);
+
+        MonthlyTopAuthor? topAuthor = await topAuthorTask;
+        MonthlyTopPost? topPost = await topPostTask;
 
         var response = new HomeStatsResponse(
             topAuthor?.ToMostActiveUserResponse(),
             topPost?.ToTopPostResponse(),
-            postsByMonth.ToPostsPerMonth());
+            (await postsByMonthTask).ToPostsPerMonth());
 
         return response;
     }

--- a/src/Lazy.Blog.Application/Posts/GetHomeStats/GetHomeStatsQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetHomeStats/GetHomeStatsQueryHandler.cs
@@ -15,10 +15,12 @@ public class GetHomeStatsQueryHandler(IPostRepository postRepository)
 
         MonthlyTopAuthor? topAuthor = await postRepository.GetMostActiveAuthorAsync(monthStart, now, ct);
         MonthlyTopPost? topPost = await postRepository.GetMostViewedPostAsync(monthStart, now, ct);
+        IReadOnlyList<MonthlyPostCount> postsByMonth = await postRepository.GetMonthlyPostCountsAsync(ct);
 
         var response = new HomeStatsResponse(
             topAuthor?.ToMostActiveUserResponse(),
-            topPost?.ToTopPostResponse());
+            topPost?.ToTopPostResponse(),
+            postsByMonth.ToPostsPerMonth());
 
         return response;
     }

--- a/src/Lazy.Blog.Application/Posts/GetHomeStats/HomeStatsResponse.cs
+++ b/src/Lazy.Blog.Application/Posts/GetHomeStats/HomeStatsResponse.cs
@@ -1,0 +1,19 @@
+using Lazy.Application.Users.GetUserById;
+
+namespace Lazy.Application.Posts.GetHomeStats;
+
+public record HomeStatsResponse(
+    MostActiveUserResponse? MostActiveUser,
+    TopPostResponse? TopPost);
+
+public record MostActiveUserResponse(
+    UserResponse User,
+    int PostCount,
+    int NetRating);
+
+public record TopPostResponse(
+    string Title,
+    string Slug,
+    string UserName,
+    long Views,
+    int NetRating);

--- a/src/Lazy.Blog.Application/Posts/GetHomeStats/HomeStatsResponse.cs
+++ b/src/Lazy.Blog.Application/Posts/GetHomeStats/HomeStatsResponse.cs
@@ -1,10 +1,12 @@
+using Lazy.Application.Posts.GetPostByUserId;
 using Lazy.Application.Users.GetUserById;
 
 namespace Lazy.Application.Posts.GetHomeStats;
 
 public record HomeStatsResponse(
     MostActiveUserResponse? MostActiveUser,
-    TopPostResponse? TopPost);
+    TopPostResponse? TopPost,
+    IReadOnlyList<PostsPerMonth> PostsByMonth);
 
 public record MostActiveUserResponse(
     UserResponse User,

--- a/src/Lazy.Blog.Application/Posts/GetPostByUserId/GetPostByIdQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostByUserId/GetPostByIdQueryHandler.cs
@@ -46,13 +46,17 @@ public class GetPostByIdQueryHandler : IQueryHandler<GetPostByUserIdQuery, UserP
 
         int totalViews = await _postRepository.GetTotalViewsByUserIdAsync(user.Id, ct);
 
+        IReadOnlyList<MonthlyPostCount> monthlyPostCounts =
+            await _postRepository.GetMonthlyPostCountsByUserIdAsync(user.Id, ct);
+
         var response = new UserPostResponse(
             new UserResponse(user),
             postDetails,
             postCount,
             voteCounts.UpVotes,
             voteCounts.DownVotes,
-            totalViews);
+            totalViews,
+            monthlyPostCounts.ToPostsPerMonth());
         return response;
     }
 }

--- a/src/Lazy.Blog.Application/Posts/GetPostByUserId/GetPostByIdQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostByUserId/GetPostByIdQueryHandler.cs
@@ -12,13 +12,16 @@ public class GetPostByIdQueryHandler : IQueryHandler<GetPostByUserIdQuery, UserP
 {
     private readonly IPostRepository _postRepository;
     private readonly IUserRepository _userRepository;
+    private readonly IPostVoteRepository _postVoteRepository;
 
     public GetPostByIdQueryHandler(
         IPostRepository postRepository,
-        IUserRepository userRepository)
+        IUserRepository userRepository,
+        IPostVoteRepository postVoteRepository)
     {
         _postRepository = postRepository;
         _userRepository = userRepository;
+        _postVoteRepository = postVoteRepository;
     }
 
     public async Task<Result<UserPostResponse>> Handle(GetPostByUserIdQuery request, CancellationToken ct)
@@ -39,7 +42,14 @@ public class GetPostByIdQueryHandler : IQueryHandler<GetPostByUserIdQuery, UserP
 
         int postCount = await _postRepository.GetPostCountByUserIdAsync(user.Id, ct);
 
-        var response = new UserPostResponse(new UserResponse(user), postDetails, postCount);
+        VoteCounts voteCounts = await _postVoteRepository.GetVoteCountsByAuthorIdAsync(user.Id, ct);
+
+        var response = new UserPostResponse(
+            new UserResponse(user),
+            postDetails,
+            postCount,
+            voteCounts.UpVotes,
+            voteCounts.DownVotes);
         return response;
     }
 }

--- a/src/Lazy.Blog.Application/Posts/GetPostByUserId/GetPostByIdQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostByUserId/GetPostByIdQueryHandler.cs
@@ -1,32 +1,20 @@
-﻿using Lazy.Application.Abstractions.Messaging;
-using Lazy.Application.Posts.Extensions;
-using Lazy.Application.Posts.GetPublishedPosts;
-using Lazy.Application.Users.GetUserById;
+using Lazy.Application.Abstractions.Messaging;
+using Lazy.Application.Posts.Shared;
 using Lazy.Domain.Entities;
 using Lazy.Domain.Repositories;
 using Lazy.Domain.Shared;
 
 namespace Lazy.Application.Posts.GetPostByUserId;
 
-public class GetPostByIdQueryHandler : IQueryHandler<GetPostByUserIdQuery, UserPostResponse>
+public class GetPostByIdQueryHandler(
+    IPostRepository postRepository,
+    IUserRepository userRepository,
+    IUserPostResponseBuilder userPostResponseBuilder)
+    : IQueryHandler<GetPostByUserIdQuery, UserPostResponse>
 {
-    private readonly IPostRepository _postRepository;
-    private readonly IUserRepository _userRepository;
-    private readonly IPostVoteRepository _postVoteRepository;
-
-    public GetPostByIdQueryHandler(
-        IPostRepository postRepository,
-        IUserRepository userRepository,
-        IPostVoteRepository postVoteRepository)
-    {
-        _postRepository = postRepository;
-        _userRepository = userRepository;
-        _postVoteRepository = postVoteRepository;
-    }
-
     public async Task<Result<UserPostResponse>> Handle(GetPostByUserIdQuery request, CancellationToken ct)
     {
-        User? user = await _userRepository.GetByIdAsync(request.UserId, ct);
+        User? user = await userRepository.GetByIdAsync(request.UserId, ct);
 
         if (user is null)
         {
@@ -35,28 +23,8 @@ public class GetPostByIdQueryHandler : IQueryHandler<GetPostByUserIdQuery, UserP
                 $"The user with Id {request.UserId} was not found."));
         }
 
-        var posts = _postRepository
-            .GetPostsByUserId(request.UserId, request.Offset, ct);
+        var posts = postRepository.GetPostsByUserId(request.UserId, request.Offset, ct);
 
-        var postDetails = posts.ToUserPostItemResponse();
-
-        int postCount = await _postRepository.GetPostCountByUserIdAsync(user.Id, ct);
-
-        VoteCounts voteCounts = await _postVoteRepository.GetVoteCountsByAuthorIdAsync(user.Id, ct);
-
-        int totalViews = await _postRepository.GetTotalViewsByUserIdAsync(user.Id, ct);
-
-        IReadOnlyList<MonthlyPostCount> monthlyPostCounts =
-            await _postRepository.GetMonthlyPostCountsByUserIdAsync(user.Id, ct);
-
-        var response = new UserPostResponse(
-            new UserResponse(user),
-            postDetails,
-            postCount,
-            voteCounts.UpVotes,
-            voteCounts.DownVotes,
-            totalViews,
-            monthlyPostCounts.ToPostsPerMonth());
-        return response;
+        return await userPostResponseBuilder.BuildAsync(user, posts, ct);
     }
 }

--- a/src/Lazy.Blog.Application/Posts/GetPostByUserId/GetPostByIdQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostByUserId/GetPostByIdQueryHandler.cs
@@ -44,12 +44,15 @@ public class GetPostByIdQueryHandler : IQueryHandler<GetPostByUserIdQuery, UserP
 
         VoteCounts voteCounts = await _postVoteRepository.GetVoteCountsByAuthorIdAsync(user.Id, ct);
 
+        int totalViews = await _postRepository.GetTotalViewsByUserIdAsync(user.Id, ct);
+
         var response = new UserPostResponse(
             new UserResponse(user),
             postDetails,
             postCount,
             voteCounts.UpVotes,
-            voteCounts.DownVotes);
+            voteCounts.DownVotes,
+            totalViews);
         return response;
     }
 }

--- a/src/Lazy.Blog.Application/Posts/GetPostByUserId/PostsPerMonth.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostByUserId/PostsPerMonth.cs
@@ -1,0 +1,3 @@
+namespace Lazy.Application.Posts.GetPostByUserId;
+
+public record PostsPerMonth(int Year, int Month, int Count);

--- a/src/Lazy.Blog.Application/Posts/GetPostByUserId/UserPostResponse.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostByUserId/UserPostResponse.cs
@@ -8,4 +8,5 @@ public record UserPostResponse(
     List<UserPostItem> PostItems,
     int TotalPostCount,
     int TotalUpVotes,
-    int TotalDownVotes);
+    int TotalDownVotes,
+    int TotalViews);

--- a/src/Lazy.Blog.Application/Posts/GetPostByUserId/UserPostResponse.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostByUserId/UserPostResponse.cs
@@ -3,4 +3,9 @@ using Lazy.Application.Users.GetUserById;
 
 namespace Lazy.Application.Posts.GetPostByUserId;
 
-public record UserPostResponse(UserResponse User, List<UserPostItem> PostItems, int TotalPostCount);
+public record UserPostResponse(
+    UserResponse User,
+    List<UserPostItem> PostItems,
+    int TotalPostCount,
+    int TotalUpVotes,
+    int TotalDownVotes);

--- a/src/Lazy.Blog.Application/Posts/GetPostByUserId/UserPostResponse.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostByUserId/UserPostResponse.cs
@@ -9,4 +9,5 @@ public record UserPostResponse(
     int TotalPostCount,
     int TotalUpVotes,
     int TotalDownVotes,
-    int TotalViews);
+    int TotalViews,
+    IReadOnlyList<PostsPerMonth> Activity);

--- a/src/Lazy.Blog.Application/Posts/GetPostByUserName/GetPostByUserNameQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostByUserName/GetPostByUserNameQueryHandler.cs
@@ -1,9 +1,7 @@
 ﻿using Lazy.Application.Abstractions.Authorization;
 using Lazy.Application.Abstractions.Messaging;
-using Lazy.Application.Posts.Extensions;
 using Lazy.Application.Posts.GetPostByUserId;
-using Lazy.Application.Posts.GetPublishedPosts;
-using Lazy.Application.Users.GetUserById;
+using Lazy.Application.Posts.Shared;
 using Lazy.Domain.Repositories;
 using Lazy.Domain.Shared;
 using Lazy.Domain.ValueObjects.User;
@@ -13,7 +11,7 @@ namespace Lazy.Application.Posts.GetPostByUserName;
 public class GetPostByUserNameQueryHandler(
     IPostRepository postRepository,
     IUserRepository userRepository,
-    IPostVoteRepository postVoteRepository,
+    IUserPostResponseBuilder userPostResponseBuilder,
     ICurrentUserContext currentUserContext)
     : IQueryHandler<GetPostByUserNameQuery, UserPostResponse>
 {
@@ -29,33 +27,10 @@ public class GetPostByUserNameQueryHandler(
                 $"The user with Username {request.UserName} was not found."));
         }
 
-        var currentUserId = currentUserContext.GetCurrentUserId();
-
-        var includeDraftPosts = currentUserId == user.Id;
-
+        var includeDraftPosts = currentUserContext.GetCurrentUserId() == user.Id;
 
         var posts = postRepository.GetPostsByUserName(userNameResult.Value, request.Offset, ct, includeDraftPosts);
 
-
-        int postCount = await postRepository.GetPostCountByUserIdAsync(user.Id, ct);
-
-        VoteCounts voteCounts = await postVoteRepository.GetVoteCountsByAuthorIdAsync(user.Id, ct);
-
-        int totalViews = await postRepository.GetTotalViewsByUserIdAsync(user.Id, ct);
-
-        IReadOnlyList<MonthlyPostCount> monthlyPostCounts =
-            await postRepository.GetMonthlyPostCountsByUserIdAsync(user.Id, ct);
-
-        List<UserPostItem> postsDetails = posts.ToUserPostItemResponse();
-
-        var response = new UserPostResponse(
-            new UserResponse(user),
-            postsDetails,
-            postCount,
-            voteCounts.UpVotes,
-            voteCounts.DownVotes,
-            totalViews,
-            monthlyPostCounts.ToPostsPerMonth());
-        return response;
+        return await userPostResponseBuilder.BuildAsync(user, posts, ct);
     }
 }

--- a/src/Lazy.Blog.Application/Posts/GetPostByUserName/GetPostByUserNameQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostByUserName/GetPostByUserNameQueryHandler.cs
@@ -41,6 +41,8 @@ public class GetPostByUserNameQueryHandler(
 
         VoteCounts voteCounts = await postVoteRepository.GetVoteCountsByAuthorIdAsync(user.Id, ct);
 
+        int totalViews = await postRepository.GetTotalViewsByUserIdAsync(user.Id, ct);
+
         List<UserPostItem> postsDetails = posts.ToUserPostItemResponse();
 
         var response = new UserPostResponse(
@@ -48,7 +50,8 @@ public class GetPostByUserNameQueryHandler(
             postsDetails,
             postCount,
             voteCounts.UpVotes,
-            voteCounts.DownVotes);
+            voteCounts.DownVotes,
+            totalViews);
         return response;
     }
 }

--- a/src/Lazy.Blog.Application/Posts/GetPostByUserName/GetPostByUserNameQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostByUserName/GetPostByUserNameQueryHandler.cs
@@ -13,6 +13,7 @@ namespace Lazy.Application.Posts.GetPostByUserName;
 public class GetPostByUserNameQueryHandler(
     IPostRepository postRepository,
     IUserRepository userRepository,
+    IPostVoteRepository postVoteRepository,
     ICurrentUserContext currentUserContext)
     : IQueryHandler<GetPostByUserNameQuery, UserPostResponse>
 {
@@ -38,9 +39,16 @@ public class GetPostByUserNameQueryHandler(
 
         int postCount = await postRepository.GetPostCountByUserIdAsync(user.Id, ct);
 
+        VoteCounts voteCounts = await postVoteRepository.GetVoteCountsByAuthorIdAsync(user.Id, ct);
+
         List<UserPostItem> postsDetails = posts.ToUserPostItemResponse();
 
-        var response = new UserPostResponse(new UserResponse(user), postsDetails, postCount);
+        var response = new UserPostResponse(
+            new UserResponse(user),
+            postsDetails,
+            postCount,
+            voteCounts.UpVotes,
+            voteCounts.DownVotes);
         return response;
     }
 }

--- a/src/Lazy.Blog.Application/Posts/GetPostByUserName/GetPostByUserNameQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Posts/GetPostByUserName/GetPostByUserNameQueryHandler.cs
@@ -43,6 +43,9 @@ public class GetPostByUserNameQueryHandler(
 
         int totalViews = await postRepository.GetTotalViewsByUserIdAsync(user.Id, ct);
 
+        IReadOnlyList<MonthlyPostCount> monthlyPostCounts =
+            await postRepository.GetMonthlyPostCountsByUserIdAsync(user.Id, ct);
+
         List<UserPostItem> postsDetails = posts.ToUserPostItemResponse();
 
         var response = new UserPostResponse(
@@ -51,7 +54,8 @@ public class GetPostByUserNameQueryHandler(
             postCount,
             voteCounts.UpVotes,
             voteCounts.DownVotes,
-            totalViews);
+            totalViews,
+            monthlyPostCounts.ToPostsPerMonth());
         return response;
     }
 }

--- a/src/Lazy.Blog.Application/Posts/Shared/IUserPostResponseBuilder.cs
+++ b/src/Lazy.Blog.Application/Posts/Shared/IUserPostResponseBuilder.cs
@@ -1,0 +1,9 @@
+using Lazy.Application.Posts.GetPostByUserId;
+using Lazy.Domain.Entities;
+
+namespace Lazy.Application.Posts.Shared;
+
+public interface IUserPostResponseBuilder
+{
+    Task<UserPostResponse> BuildAsync(User user, IQueryable<Post> posts, CancellationToken ct);
+}

--- a/src/Lazy.Blog.Application/Posts/Shared/UserPostResponseBuilder.cs
+++ b/src/Lazy.Blog.Application/Posts/Shared/UserPostResponseBuilder.cs
@@ -1,0 +1,37 @@
+using Lazy.Application.Posts.Extensions;
+using Lazy.Application.Posts.GetPostByUserId;
+using Lazy.Application.Posts.GetPublishedPosts;
+using Lazy.Application.Users.GetUserById;
+using Lazy.Domain.Entities;
+using Lazy.Domain.Repositories;
+
+namespace Lazy.Application.Posts.Shared;
+
+public class UserPostResponseBuilder(
+    IPostRepository postRepository,
+    IPostVoteRepository postVoteRepository) : IUserPostResponseBuilder
+{
+    public async Task<UserPostResponse> BuildAsync(User user, IQueryable<Post> posts, CancellationToken ct)
+    {
+        List<UserPostItem> postsDetails = posts.ToUserPostItemResponse();
+
+        Task<int> postCountTask = postRepository.GetPostCountByUserIdAsync(user.Id, ct);
+        Task<VoteCounts> voteCountsTask = postVoteRepository.GetVoteCountsByAuthorIdAsync(user.Id, ct);
+        Task<int> totalViewsTask = postRepository.GetTotalViewsByUserIdAsync(user.Id, ct);
+        Task<IReadOnlyList<MonthlyPostCount>> monthlyPostCountsTask =
+            postRepository.GetMonthlyPostCountsByUserIdAsync(user.Id, ct);
+
+        await Task.WhenAll(postCountTask, voteCountsTask, totalViewsTask, monthlyPostCountsTask);
+
+        VoteCounts voteCounts = await voteCountsTask;
+
+        return new UserPostResponse(
+            new UserResponse(user),
+            postsDetails,
+            await postCountTask,
+            voteCounts.UpVotes,
+            voteCounts.DownVotes,
+            await totalViewsTask,
+            (await monthlyPostCountsTask).ToPostsPerMonth());
+    }
+}

--- a/src/Lazy.Blog.Application/Posts/Shared/UserPostResponseBuilder.cs
+++ b/src/Lazy.Blog.Application/Posts/Shared/UserPostResponseBuilder.cs
@@ -23,15 +23,15 @@ public class UserPostResponseBuilder(
 
         await Task.WhenAll(postCountTask, voteCountsTask, totalViewsTask, monthlyPostCountsTask);
 
-        VoteCounts voteCounts = await voteCountsTask;
+        VoteCounts voteCounts = voteCountsTask.Result;
 
         return new UserPostResponse(
             new UserResponse(user),
             postsDetails,
-            await postCountTask,
+            postCountTask.Result,
             voteCounts.UpVotes,
             voteCounts.DownVotes,
-            await totalViewsTask,
-            (await monthlyPostCountsTask).ToPostsPerMonth());
+            totalViewsTask.Result,
+            monthlyPostCountsTask.Result.ToPostsPerMonth());
     }
 }

--- a/src/Lazy.Blog.Domain/Repositories/IPostRepository.cs
+++ b/src/Lazy.Blog.Domain/Repositories/IPostRepository.cs
@@ -27,6 +27,7 @@ public interface IPostRepository
     Task<int> GetPostCountByUserIdAsync(Guid userId, CancellationToken ct);
     Task<int> GetTotalViewsByUserIdAsync(Guid userId, CancellationToken ct);
     Task<IReadOnlyList<MonthlyPostCount>> GetMonthlyPostCountsByUserIdAsync(Guid userId, CancellationToken ct);
+    Task<IReadOnlyList<MonthlyPostCount>> GetMonthlyPostCountsAsync(CancellationToken ct);
     Task<MonthlyTopAuthor?> GetMostActiveAuthorAsync(DateTime fromUtc, DateTime toUtc, CancellationToken ct);
     Task<MonthlyTopPost?> GetMostViewedPostAsync(DateTime fromUtc, DateTime toUtc, CancellationToken ct);
 }

--- a/src/Lazy.Blog.Domain/Repositories/IPostRepository.cs
+++ b/src/Lazy.Blog.Domain/Repositories/IPostRepository.cs
@@ -26,4 +26,5 @@ public interface IPostRepository
     IQueryable<Post> GetPagedPosts(int requestOffset, CancellationToken ct);
     Task<int> GetPostCountByUserIdAsync(Guid userId, CancellationToken ct);
     Task<int> GetTotalViewsByUserIdAsync(Guid userId, CancellationToken ct);
+    Task<IReadOnlyList<MonthlyPostCount>> GetMonthlyPostCountsByUserIdAsync(Guid userId, CancellationToken ct);
 }

--- a/src/Lazy.Blog.Domain/Repositories/IPostRepository.cs
+++ b/src/Lazy.Blog.Domain/Repositories/IPostRepository.cs
@@ -25,4 +25,5 @@ public interface IPostRepository
     IQueryable<Post> GetPostsByUserName(UserName userName, int offset, CancellationToken ct, bool includeDrafts = false);
     IQueryable<Post> GetPagedPosts(int requestOffset, CancellationToken ct);
     Task<int> GetPostCountByUserIdAsync(Guid userId, CancellationToken ct);
+    Task<int> GetTotalViewsByUserIdAsync(Guid userId, CancellationToken ct);
 }

--- a/src/Lazy.Blog.Domain/Repositories/IPostRepository.cs
+++ b/src/Lazy.Blog.Domain/Repositories/IPostRepository.cs
@@ -27,4 +27,6 @@ public interface IPostRepository
     Task<int> GetPostCountByUserIdAsync(Guid userId, CancellationToken ct);
     Task<int> GetTotalViewsByUserIdAsync(Guid userId, CancellationToken ct);
     Task<IReadOnlyList<MonthlyPostCount>> GetMonthlyPostCountsByUserIdAsync(Guid userId, CancellationToken ct);
+    Task<MonthlyTopAuthor?> GetMostActiveAuthorAsync(DateTime fromUtc, DateTime toUtc, CancellationToken ct);
+    Task<MonthlyTopPost?> GetMostViewedPostAsync(DateTime fromUtc, DateTime toUtc, CancellationToken ct);
 }

--- a/src/Lazy.Blog.Domain/Repositories/IPostVoteRepository.cs
+++ b/src/Lazy.Blog.Domain/Repositories/IPostVoteRepository.cs
@@ -11,5 +11,7 @@ public interface IPostVoteRepository
 
     IQueryable<PostVote> GetPostVotesByPostId(Guid postId, CancellationToken ct);
 
+    Task<VoteCounts> GetVoteCountsByAuthorIdAsync(Guid authorId, CancellationToken ct);
+
     void Update(PostVote vote);
 }

--- a/src/Lazy.Blog.Domain/Repositories/MonthlyPostCount.cs
+++ b/src/Lazy.Blog.Domain/Repositories/MonthlyPostCount.cs
@@ -1,0 +1,3 @@
+namespace Lazy.Domain.Repositories;
+
+public readonly record struct MonthlyPostCount(int Year, int Month, int Count);

--- a/src/Lazy.Blog.Domain/Repositories/MonthlyTopAuthor.cs
+++ b/src/Lazy.Blog.Domain/Repositories/MonthlyTopAuthor.cs
@@ -1,0 +1,5 @@
+using Lazy.Domain.Entities;
+
+namespace Lazy.Domain.Repositories;
+
+public sealed record MonthlyTopAuthor(User User, int PostCount, int NetRating);

--- a/src/Lazy.Blog.Domain/Repositories/MonthlyTopPost.cs
+++ b/src/Lazy.Blog.Domain/Repositories/MonthlyTopPost.cs
@@ -1,0 +1,3 @@
+namespace Lazy.Domain.Repositories;
+
+public sealed record MonthlyTopPost(string Title, string Slug, string UserName, long Views, int NetRating);

--- a/src/Lazy.Blog.Domain/Repositories/VoteCounts.cs
+++ b/src/Lazy.Blog.Domain/Repositories/VoteCounts.cs
@@ -1,0 +1,3 @@
+namespace Lazy.Domain.Repositories;
+
+public readonly record struct VoteCounts(int UpVotes, int DownVotes);

--- a/src/Lazy.Blog.Persistence/Repositories/PostRepository.cs
+++ b/src/Lazy.Blog.Persistence/Repositories/PostRepository.cs
@@ -128,5 +128,17 @@ public class PostRepository(LazyBlogDbContext dbContext) : IPostRepository
         return (int)totalViews;
     }
 
+    public async Task<IReadOnlyList<MonthlyPostCount>> GetMonthlyPostCountsByUserIdAsync(Guid userId, CancellationToken ct)
+    {
+        var monthlyPostCounts = await dbContext.Set<Post>()
+            .Where(p => p.UserId == userId && p.IsPublished)
+            .GroupBy(p => new { p.CreatedOnUtc.Year, p.CreatedOnUtc.Month })
+            .OrderBy(g => g.Key.Year)
+            .ThenBy(g => g.Key.Month)
+            .Select(g => new MonthlyPostCount(g.Key.Year, g.Key.Month, g.Count()))
+            .ToListAsync(ct);
+        return monthlyPostCounts;
+    }
+
     public void Delete(Post post) => dbContext.Set<Post>().Remove(post);
 }

--- a/src/Lazy.Blog.Persistence/Repositories/PostRepository.cs
+++ b/src/Lazy.Blog.Persistence/Repositories/PostRepository.cs
@@ -119,6 +119,14 @@ public class PostRepository(LazyBlogDbContext dbContext) : IPostRepository
             .CountAsync(cancellationToken: ct);
         return postCount;
     }
-    
+
+    public async Task<int> GetTotalViewsByUserIdAsync(Guid userId, CancellationToken ct)
+    {
+        long totalViews = await dbContext.Set<Post>()
+            .Where(p => p.UserId == userId)
+            .SumAsync(p => (long?)p.Views, ct) ?? 0;
+        return (int)totalViews;
+    }
+
     public void Delete(Post post) => dbContext.Set<Post>().Remove(post);
 }

--- a/src/Lazy.Blog.Persistence/Repositories/PostRepository.cs
+++ b/src/Lazy.Blog.Persistence/Repositories/PostRepository.cs
@@ -140,6 +140,18 @@ public class PostRepository(LazyBlogDbContext dbContext) : IPostRepository
         return monthlyPostCounts;
     }
 
+    public async Task<IReadOnlyList<MonthlyPostCount>> GetMonthlyPostCountsAsync(CancellationToken ct)
+    {
+        var monthlyPostCounts = await dbContext.Set<Post>()
+            .Where(p => p.IsPublished)
+            .GroupBy(p => new { p.CreatedOnUtc.Year, p.CreatedOnUtc.Month })
+            .OrderBy(g => g.Key.Year)
+            .ThenBy(g => g.Key.Month)
+            .Select(g => new MonthlyPostCount(g.Key.Year, g.Key.Month, g.Count()))
+            .ToListAsync(ct);
+        return monthlyPostCounts;
+    }
+
     public async Task<MonthlyTopAuthor?> GetMostActiveAuthorAsync(DateTime fromUtc, DateTime toUtc, CancellationToken ct)
     {
         var topAuthor = await dbContext.Set<Post>()

--- a/src/Lazy.Blog.Persistence/Repositories/PostRepository.cs
+++ b/src/Lazy.Blog.Persistence/Repositories/PostRepository.cs
@@ -140,5 +140,53 @@ public class PostRepository(LazyBlogDbContext dbContext) : IPostRepository
         return monthlyPostCounts;
     }
 
+    public async Task<MonthlyTopAuthor?> GetMostActiveAuthorAsync(DateTime fromUtc, DateTime toUtc, CancellationToken ct)
+    {
+        var topAuthor = await dbContext.Set<Post>()
+            .Where(p => p.IsPublished && p.CreatedOnUtc >= fromUtc && p.CreatedOnUtc <= toUtc)
+            .GroupBy(p => p.UserId)
+            .Select(g => new
+            {
+                UserId = g.Key,
+                PostCount = g.Count(),
+                NetRating = g.Sum(p => p.Rating)
+            })
+            .OrderByDescending(g => g.PostCount)
+            .ThenByDescending(g => g.NetRating)
+            .FirstOrDefaultAsync(ct);
+
+        if (topAuthor is null)
+        {
+            return null;
+        }
+
+        var user = await dbContext.Set<User>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == topAuthor.UserId, ct);
+
+        if (user is null)
+        {
+            return null;
+        }
+
+        return new MonthlyTopAuthor(user, topAuthor.PostCount, topAuthor.NetRating);
+    }
+
+    public async Task<MonthlyTopPost?> GetMostViewedPostAsync(DateTime fromUtc, DateTime toUtc, CancellationToken ct)
+    {
+        var topPost = await dbContext.Set<Post>()
+            .Where(p => p.IsPublished && p.CreatedOnUtc >= fromUtc && p.CreatedOnUtc <= toUtc)
+            .OrderByDescending(p => p.Views)
+            .Select(p => new MonthlyTopPost(
+                p.Title.Value,
+                p.Slug.Value,
+                p.User.UserName!,
+                p.Views,
+                p.Rating))
+            .FirstOrDefaultAsync(ct);
+
+        return topPost;
+    }
+
     public void Delete(Post post) => dbContext.Set<Post>().Remove(post);
 }

--- a/src/Lazy.Blog.Persistence/Repositories/PostRepository.cs
+++ b/src/Lazy.Blog.Persistence/Repositories/PostRepository.cs
@@ -7,7 +7,9 @@ using static Lazy.Persistence.Constants.QueryConstants;
 
 namespace Lazy.Persistence.Repositories;
 
-public class PostRepository(LazyBlogDbContext dbContext) : IPostRepository
+public class PostRepository(
+    LazyBlogDbContext dbContext,
+    IDbContextFactory<LazyBlogDbContext> dbContextFactory) : IPostRepository
 {
     public async Task<Post?> GetByIdAsync(Guid postId, CancellationToken ct) =>
         await dbContext
@@ -114,7 +116,9 @@ public class PostRepository(LazyBlogDbContext dbContext) : IPostRepository
 
     public async Task<int> GetPostCountByUserIdAsync(Guid userId, CancellationToken ct)
     {
-        var postCount = await dbContext.Set<Post>()
+        await using var ctx = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var postCount = await ctx.Set<Post>()
             .Where(p => p.UserId == userId && p.IsPublished)
             .CountAsync(cancellationToken: ct);
         return postCount;
@@ -122,7 +126,9 @@ public class PostRepository(LazyBlogDbContext dbContext) : IPostRepository
 
     public async Task<int> GetTotalViewsByUserIdAsync(Guid userId, CancellationToken ct)
     {
-        long totalViews = await dbContext.Set<Post>()
+        await using var ctx = await dbContextFactory.CreateDbContextAsync(ct);
+
+        long totalViews = await ctx.Set<Post>()
             .Where(p => p.UserId == userId)
             .SumAsync(p => (long?)p.Views, ct) ?? 0;
         return (int)totalViews;
@@ -130,7 +136,9 @@ public class PostRepository(LazyBlogDbContext dbContext) : IPostRepository
 
     public async Task<IReadOnlyList<MonthlyPostCount>> GetMonthlyPostCountsByUserIdAsync(Guid userId, CancellationToken ct)
     {
-        var monthlyPostCounts = await dbContext.Set<Post>()
+        await using var ctx = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var monthlyPostCounts = await ctx.Set<Post>()
             .Where(p => p.UserId == userId && p.IsPublished)
             .GroupBy(p => new { p.CreatedOnUtc.Year, p.CreatedOnUtc.Month })
             .OrderBy(g => g.Key.Year)
@@ -142,7 +150,9 @@ public class PostRepository(LazyBlogDbContext dbContext) : IPostRepository
 
     public async Task<IReadOnlyList<MonthlyPostCount>> GetMonthlyPostCountsAsync(CancellationToken ct)
     {
-        var monthlyPostCounts = await dbContext.Set<Post>()
+        await using var ctx = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var monthlyPostCounts = await ctx.Set<Post>()
             .Where(p => p.IsPublished)
             .GroupBy(p => new { p.CreatedOnUtc.Year, p.CreatedOnUtc.Month })
             .OrderBy(g => g.Key.Year)
@@ -154,7 +164,9 @@ public class PostRepository(LazyBlogDbContext dbContext) : IPostRepository
 
     public async Task<MonthlyTopAuthor?> GetMostActiveAuthorAsync(DateTime fromUtc, DateTime toUtc, CancellationToken ct)
     {
-        var topAuthor = await dbContext.Set<Post>()
+        await using var ctx = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var topAuthor = await ctx.Set<Post>()
             .Where(p => p.IsPublished && p.CreatedOnUtc >= fromUtc && p.CreatedOnUtc <= toUtc)
             .GroupBy(p => p.UserId)
             .Select(g => new
@@ -172,7 +184,7 @@ public class PostRepository(LazyBlogDbContext dbContext) : IPostRepository
             return null;
         }
 
-        var user = await dbContext.Set<User>()
+        var user = await ctx.Set<User>()
             .AsNoTracking()
             .FirstOrDefaultAsync(u => u.Id == topAuthor.UserId, ct);
 
@@ -186,7 +198,9 @@ public class PostRepository(LazyBlogDbContext dbContext) : IPostRepository
 
     public async Task<MonthlyTopPost?> GetMostViewedPostAsync(DateTime fromUtc, DateTime toUtc, CancellationToken ct)
     {
-        var topPost = await dbContext.Set<Post>()
+        await using var ctx = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var topPost = await ctx.Set<Post>()
             .Where(p => p.IsPublished && p.CreatedOnUtc >= fromUtc && p.CreatedOnUtc <= toUtc)
             .OrderByDescending(p => p.Views)
             .Select(p => new MonthlyTopPost(

--- a/src/Lazy.Blog.Persistence/Repositories/PostVoteRepository.cs
+++ b/src/Lazy.Blog.Persistence/Repositories/PostVoteRepository.cs
@@ -5,26 +5,22 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Lazy.Persistence.Repositories;
 
-public class PostVoteRepository : IPostVoteRepository
+public class PostVoteRepository(
+    LazyBlogDbContext dbContext,
+    IDbContextFactory<LazyBlogDbContext> dbContextFactory) : IPostVoteRepository
 {
-    private readonly LazyBlogDbContext _dbContext;
-
-    public PostVoteRepository(LazyBlogDbContext dbContext)
-        => _dbContext = dbContext;
-
-
     public void Add(PostVote vote) =>
-        _dbContext.Set<PostVote>().Add(vote);
+        dbContext.Set<PostVote>().Add(vote);
 
     public void Delete(PostVote vote) =>
-        _dbContext.Set<PostVote>().Remove(vote);
+        dbContext.Set<PostVote>().Remove(vote);
 
     public async Task<PostVote?> GetPostVoteForUserIdAsync(
-        Guid userId, 
+        Guid userId,
         Guid postId,
         CancellationToken ct)
     {
-        return await _dbContext.Set<PostVote>()
+        return await dbContext.Set<PostVote>()
             .AsNoTracking()
             .Where(pv => pv.PostId == postId)
             .Include(pv => pv.Post)
@@ -33,14 +29,16 @@ public class PostVoteRepository : IPostVoteRepository
     }
 
     public IQueryable<PostVote> GetPostVotesByPostId(Guid postId, CancellationToken ct) =>
-        _dbContext.Set<PostVote>()
+        dbContext.Set<PostVote>()
             .AsNoTracking()
             .Where(pv => pv.PostId == postId)
             .OrderBy(pv => pv.CreatedOnUtc);
 
     public async Task<VoteCounts> GetVoteCountsByAuthorIdAsync(Guid authorId, CancellationToken ct)
     {
-        var counts = await _dbContext.Set<PostVote>()
+        await using var ctx = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var counts = await ctx.Set<PostVote>()
             .AsNoTracking()
             .Where(pv => pv.Post.UserId == authorId)
             .GroupBy(pv => pv.VoteDirection)
@@ -54,5 +52,5 @@ public class PostVoteRepository : IPostVoteRepository
     }
 
     public void Update(PostVote vote) =>
-        _dbContext.Set<PostVote>().Update(vote);
+        dbContext.Set<PostVote>().Update(vote);
 }

--- a/src/Lazy.Blog.Persistence/Repositories/PostVoteRepository.cs
+++ b/src/Lazy.Blog.Persistence/Repositories/PostVoteRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Lazy.Domain.Entities;
 using Lazy.Domain.Repositories;
+using Lazy.Domain.ValueObjects.Post;
 using Microsoft.EntityFrameworkCore;
 
 namespace Lazy.Persistence.Repositories;
@@ -36,6 +37,21 @@ public class PostVoteRepository : IPostVoteRepository
             .AsNoTracking()
             .Where(pv => pv.PostId == postId)
             .OrderBy(pv => pv.CreatedOnUtc);
+
+    public async Task<VoteCounts> GetVoteCountsByAuthorIdAsync(Guid authorId, CancellationToken ct)
+    {
+        var counts = await _dbContext.Set<PostVote>()
+            .AsNoTracking()
+            .Where(pv => pv.Post.UserId == authorId)
+            .GroupBy(pv => pv.VoteDirection)
+            .Select(g => new { Direction = g.Key, Count = g.Count() })
+            .ToListAsync(ct);
+
+        int upVotes = counts.SingleOrDefault(c => c.Direction == VoteDirection.Up)?.Count ?? 0;
+        int downVotes = counts.SingleOrDefault(c => c.Direction == VoteDirection.Down)?.Count ?? 0;
+
+        return new VoteCounts(upVotes, downVotes);
+    }
 
     public void Update(PostVote vote) =>
         _dbContext.Set<PostVote>().Update(vote);

--- a/src/Lazy.Blog.Presentation/Controllers/PostsController.cs
+++ b/src/Lazy.Blog.Presentation/Controllers/PostsController.cs
@@ -8,6 +8,7 @@ using Lazy.Application.Posts.GetPostById;
 using Lazy.Application.Posts.GetPostBySlug;
 using Lazy.Application.Posts.GetPostByTag;
 using Lazy.Application.Posts.GetPostByUserId;
+using Lazy.Application.Posts.GetHomeStats;
 using Lazy.Application.Posts.GetPostByUserName;
 using Lazy.Application.Posts.GetPostRatingHistory;
 using Lazy.Application.Posts.GetPublishedPosts;
@@ -66,6 +67,19 @@ public class PostsController : BaseJwtController
         }
 
         return result.IsSuccess ? Ok(result.Value) : BadRequest(result.Error);
+    }
+
+    [AllowAnonymous]
+    [HttpGet("stats", Name = nameof(GetHomeStats))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HomeStatsResponse))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetHomeStats(CancellationToken ct)
+    {
+        var query = new GetHomeStatsQuery();
+
+        Result<HomeStatsResponse> response = await Sender.Send(query, ct);
+
+        return response.IsSuccess ? Ok(response.Value) : HandleFailure(response);
     }
 
     [AllowAnonymous]

--- a/src/Lazy.Blog.Presentation/Controllers/PostsController.cs
+++ b/src/Lazy.Blog.Presentation/Controllers/PostsController.cs
@@ -8,7 +8,6 @@ using Lazy.Application.Posts.GetPostById;
 using Lazy.Application.Posts.GetPostBySlug;
 using Lazy.Application.Posts.GetPostByTag;
 using Lazy.Application.Posts.GetPostByUserId;
-using Lazy.Application.Posts.GetHomeStats;
 using Lazy.Application.Posts.GetPostByUserName;
 using Lazy.Application.Posts.GetPostRatingHistory;
 using Lazy.Application.Posts.GetPublishedPosts;
@@ -67,19 +66,6 @@ public class PostsController : BaseJwtController
         }
 
         return result.IsSuccess ? Ok(result.Value) : BadRequest(result.Error);
-    }
-
-    [AllowAnonymous]
-    [HttpGet("stats", Name = nameof(GetHomeStats))]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HomeStatsResponse))]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> GetHomeStats(CancellationToken ct)
-    {
-        var query = new GetHomeStatsQuery();
-
-        Result<HomeStatsResponse> response = await Sender.Send(query, ct);
-
-        return response.IsSuccess ? Ok(response.Value) : HandleFailure(response);
     }
 
     [AllowAnonymous]

--- a/src/Lazy.Blog.Presentation/Controllers/StatsController.cs
+++ b/src/Lazy.Blog.Presentation/Controllers/StatsController.cs
@@ -1,0 +1,33 @@
+using Lazy.Application.Posts.GetHomeStats;
+using Lazy.Domain.Shared;
+using Lazy.Presentation.Abstractions;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Lazy.Presentation.Controllers;
+
+[Authorize]
+[Route("api/stats")]
+public class StatsController : BaseJwtController
+{
+    public StatsController(ISender sender, ILogger<StatsController> logger)
+        : base(sender, logger)
+    {
+    }
+
+    [AllowAnonymous]
+    [HttpGet(Name = nameof(GetHomeStats))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HomeStatsResponse))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetHomeStats(CancellationToken ct)
+    {
+        var query = new GetHomeStatsQuery();
+
+        Result<HomeStatsResponse> response = await Sender.Send(query, ct);
+
+        return response.IsSuccess ? Ok(response.Value) : HandleFailure(response);
+    }
+}


### PR DESCRIPTION
## Summary
  Adds server-computed statistics to power the redesigned profile and home pages,
  replacing the frontend's current feed-derived approximations with accurate,
  DB-side aggregates. Purely additive to the API surface — no breaking changes,
  no migrations.

  ## Profile — extends `UserPostResponse` (`GET api/posts/by-username/{userName}` & `by-id`)
  - **`TotalUpVotes` / `TotalDownVotes`** — likes/dislikes received across all of
    the author's posts (grouped count of vote rows).
  - **`TotalViews`** — sum of views across all the author's posts.
  - **`Activity`** — per-month published-post counts (`{ year, month, count }`)
    for the profile activity sparkline.

  ## Home — new endpoint `GET api/posts/stats` → `HomeStatsResponse`
  - **`MostActiveUser`** — author with the most posts published in the current
    (UTC) calendar month, with their post count + net rating. `null` when the
    month has no posts yet (the client renders its own empty state — no
    last-month fallback, the API reports the current month truthfully).
  - **`TopPost`** — most-viewed post published this month (title, slug, author
    handle, views, net rating). `null` when empty.
  - **`PostsByMonth`** — global per-month published-post counts for the
    "posts by month" sparkline.
  
  ## Implementation notes
  - All aggregates are computed **DB-side** (`GroupBy` / `Sum` / `Count`,
    single round-trips, no N+1, no row materialization).
  - Counts use the existing **published-only** filter, so they reconcile with
    `TotalPostCount`.
  - Repository returns domain-side primitives (`VoteCounts`, `MonthlyPostCount`,
    …); mapping to response records happens in the handlers (existing layering).
  - **No migrations** — pure read aggregates over existing data.

  ## Commits
  1. `feat(posts): add total up/down vote counts to user-profile response`
  2. `feat(posts): add total views to user-profile response`
  3. `feat(posts): add monthly post activity to user-profile response`
  4. `feat(stats): add home monthly highlights endpoint (most active user + top post)`
  5. `feat(stats): add global posts-by-month series to home stats`
  
  ## Frontend
  Additive contract change — the OpenAPI client must be regenerated (`gen:api`)
  to surface the new fields/endpoint. No existing route or response shape was
  removed or retyped.