### PR TITLE
feat(auth): add POST /api/users/logout to revoke the refresh token

### DIFF
--- a/src/Lazy.Blog.Application/Users/Logout/LogoutCommand.cs
+++ b/src/Lazy.Blog.Application/Users/Logout/LogoutCommand.cs
@@ -1,0 +1,5 @@
+using Lazy.Application.Abstractions.Messaging;
+
+namespace Lazy.Application.Users.Logout;
+
+public record LogoutCommand(string RefreshToken) : ICommand;

--- a/src/Lazy.Blog.Application/Users/Logout/LogoutCommandHandler.cs
+++ b/src/Lazy.Blog.Application/Users/Logout/LogoutCommandHandler.cs
@@ -1,0 +1,34 @@
+using Lazy.Application.Abstractions.Authorization;
+using Lazy.Application.Abstractions.Messaging;
+using Lazy.Domain.Entities.Identity;
+using Lazy.Domain.Repositories;
+using Lazy.Domain.Repositories.Identity;
+using Lazy.Domain.Shared;
+
+namespace Lazy.Application.Users.Logout;
+
+public class LogoutCommandHandler(
+    IUserTokenRepository userTokenRepository,
+    ICurrentUserContext currentUserContext,
+    IUnitOfWork unitOfWork)
+    : ICommandHandler<LogoutCommand>
+{
+    public async Task<Result> Handle(LogoutCommand request, CancellationToken cancellationToken)
+    {
+        UserToken? storedRefreshToken =
+            await userTokenRepository.GetByRefreshTokenAsync(request.RefreshToken, cancellationToken);
+
+        if (storedRefreshToken is null ||
+            storedRefreshToken.UserId != currentUserContext.GetCurrentUserId())
+        {
+            return Result.Success();
+        }
+
+        storedRefreshToken.Invalidate();
+        userTokenRepository.Update(storedRefreshToken);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/src/Lazy.Blog.Domain/Errors/DomainErrors.cs
+++ b/src/Lazy.Blog.Domain/Errors/DomainErrors.cs
@@ -57,7 +57,7 @@ public static class DomainErrors
 
 
         public static readonly Error NotMatched = new(
-            "UserToken.IsUsed",
+            "UserToken.NotMatched",
             "The provided token doesn't match with access token");
     }
 

--- a/src/Lazy.Blog.Presentation/Contracts/Users/LogoutRequest.cs
+++ b/src/Lazy.Blog.Presentation/Contracts/Users/LogoutRequest.cs
@@ -1,0 +1,6 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Lazy.Presentation.Contracts.Users;
+
+public sealed record LogoutRequest(
+    [Required] string RefreshToken);

--- a/src/Lazy.Blog.Presentation/Controllers/UsersController.cs
+++ b/src/Lazy.Blog.Presentation/Controllers/UsersController.cs
@@ -4,6 +4,7 @@ using Lazy.Application.Users.CreateUser;
 using Lazy.Application.Users.DeleteUserAvatar;
 using Lazy.Application.Users.GetUserById;
 using Lazy.Application.Users.Login;
+using Lazy.Application.Users.Logout;
 using Lazy.Application.Users.RefreshToken;
 using Lazy.Application.Users.UpdateUser;
 using Lazy.Application.Users.UploadUserAvatar;
@@ -109,6 +110,19 @@ public class UsersController : BaseJwtController
         var result = await Sender.Send(command, cancellationToken);
 
         return result.IsFailure ? HandleFailure(result) : Ok(result.Value);
+    }
+
+    [HttpPost("logout", Name = nameof(Logout))]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> Logout(
+        [FromBody] LogoutRequest request,
+        CancellationToken ct)
+    {
+        var command = new LogoutCommand(request.RefreshToken);
+
+        await Sender.Send(command, ct);
+
+        return NoContent();
     }
 
     [AllowAnonymous]


### PR DESCRIPTION
Logout was client-only: the refresh token stayed valid server-side for its full lifetime, so a 'logged out' session could keep minting access tokens (account-takeover window on shared/stolen devices). This invalidates the presented refresh token, reusing the same Invalidate() path change-password already uses.

- LogoutCommand/Handler (CQRS): look up the refresh token, verify it belongs to the authenticated caller, Invalidate() + persist. Idempotent - an unknown / already-used / not-owned token returns success quietly (the client is logging out regardless).
- POST /api/users/logout: authenticated, body { refreshToken }, 204 No Content.
- fix: DomainErrors.UserToken.NotMatched shipped the wrong code ('UserToken.IsUsed') so the two errors were indistinguishable - corrected.

No migration (IsInvalidated / Invalidate() already exist).