### PR TITLE
fix(di): register Application-layer services + validate container on …

### DIFF
--- a/src/Lazy.Blog.Api/Program.cs
+++ b/src/Lazy.Blog.Api/Program.cs
@@ -37,6 +37,12 @@ try
 {
     var builder = WebApplication.CreateBuilder(args);
 
+    builder.Host.UseDefaultServiceProvider((context, options) =>
+    {
+        options.ValidateScopes = true;
+        options.ValidateOnBuild = true;
+    });
+
 
     builder.Services.Configure<ForwardedHeadersOptions>(options =>
     {
@@ -64,6 +70,7 @@ try
             selector => selector
                 .FromAssemblies(
                     AssemblyReference.Assembly,
+                    Lazy.Application.AssemblyReference.Assembly,
                     Lazy.Persistence.AssemblyReference.Assembly)
                 .AddClasses(false)
                 .UsingRegistrationStrategy(RegistrationStrategy.Skip)


### PR DESCRIPTION
…build

GetPostByUserNameQueryHandler (GET /api/posts/{userName}/posts) and the GetPostById handler depend on IUserPostResponseBuilder (extracted into Application/Posts/Shared in #90), but the Scrutor convention scan only covered Infrastructure + Persistence - never Lazy.Application - so IUserPostResponseBuilder was never registered and both profile queries threw 'Unable to resolve service' (a 500 that surfaced intermittently across the rolling deploy).

- add Lazy.Application.AssemblyReference.Assembly to the .FromAssemblies(...) scan; the I{Name}->{Name} convention now covers Application helpers too (RegistrationStrategy.Skip + AsMatchingInterface leave MediatR handlers / validators untouched; Scoped lifetime matches the repos it depends on).
- enable ValidateScopes + ValidateOnBuild so a missing / captive dependency fails at startup instead of becoming a runtime 500 (container verified clean).

No migration.