### PR TITLE
feat(arcade): score submission, leaderboard + per-user stats

### DIFF
--- a/src/Lazy.Blog.Api/Program.cs
+++ b/src/Lazy.Blog.Api/Program.cs
@@ -37,6 +37,12 @@ try
 {
     var builder = WebApplication.CreateBuilder(args);
 
+    builder.Host.UseDefaultServiceProvider((context, options) =>
+    {
+        options.ValidateScopes = true;
+        options.ValidateOnBuild = true;
+    });
+
 
     builder.Services.Configure<ForwardedHeadersOptions>(options =>
     {
@@ -64,6 +70,7 @@ try
             selector => selector
                 .FromAssemblies(
                     AssemblyReference.Assembly,
+                    Lazy.Application.AssemblyReference.Assembly,
                     Lazy.Persistence.AssemblyReference.Assembly)
                 .AddClasses(false)
                 .UsingRegistrationStrategy(RegistrationStrategy.Skip)

--- a/src/Lazy.Blog.Application/Arcade/Extensions/ArcadeMapper.cs
+++ b/src/Lazy.Blog.Application/Arcade/Extensions/ArcadeMapper.cs
@@ -1,0 +1,23 @@
+using Lazy.Application.Arcade.GetLeaderboard;
+using Lazy.Application.Arcade.GetMyArcadeStats;
+using Lazy.Domain.Repositories;
+using Lazy.Domain.ValueObjects.Arcade;
+
+namespace Lazy.Application.Arcade.Extensions;
+
+public static class ArcadeMapper
+{
+    public static ArcadeStatsResponse ToArcadeStatsResponse(this ArcadeUserStats stats, GameKey game) =>
+        new(game.Value, stats.BestScore, stats.GamesPlayed, stats.Rank);
+
+    public static IReadOnlyList<LeaderboardEntryResponse> ToLeaderboardResponse(
+        this IReadOnlyList<LeaderboardEntry> entries) =>
+        entries
+            .Select((entry, index) => new LeaderboardEntryResponse(
+                index + 1,
+                entry.UserName,
+                entry.AvatarUrl,
+                entry.BestScore,
+                entry.GamesPlayed))
+            .ToList();
+}

--- a/src/Lazy.Blog.Application/Arcade/GetLeaderboard/GetLeaderboardQuery.cs
+++ b/src/Lazy.Blog.Application/Arcade/GetLeaderboard/GetLeaderboardQuery.cs
@@ -1,0 +1,5 @@
+using Lazy.Application.Abstractions.Messaging;
+
+namespace Lazy.Application.Arcade.GetLeaderboard;
+
+public record GetLeaderboardQuery(string Game, int Take) : IQuery<LeaderboardResponse>;

--- a/src/Lazy.Blog.Application/Arcade/GetLeaderboard/GetLeaderboardQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Arcade/GetLeaderboard/GetLeaderboardQueryHandler.cs
@@ -1,0 +1,33 @@
+using Lazy.Application.Abstractions.Messaging;
+using Lazy.Application.Arcade.Extensions;
+using Lazy.Domain.Repositories;
+using Lazy.Domain.Shared;
+using Lazy.Domain.ValueObjects.Arcade;
+
+namespace Lazy.Application.Arcade.GetLeaderboard;
+
+public class GetLeaderboardQueryHandler(IArcadeScoreRepository arcadeScoreRepository)
+    : IQueryHandler<GetLeaderboardQuery, LeaderboardResponse>
+{
+    private const int DefaultTake = 10;
+    private const int MaxTake = 100;
+
+    public async Task<Result<LeaderboardResponse>> Handle(GetLeaderboardQuery request, CancellationToken ct)
+    {
+        Result<GameKey> gameKeyResult = GameKey.Create(request.Game);
+
+        if (gameKeyResult.IsFailure)
+        {
+            return Result.Failure<LeaderboardResponse>(gameKeyResult.Error);
+        }
+
+        GameKey game = gameKeyResult.Value;
+
+        int take = request.Take <= 0 ? DefaultTake : Math.Min(request.Take, MaxTake);
+
+        IReadOnlyList<LeaderboardEntry> entries =
+            await arcadeScoreRepository.GetLeaderboardAsync(game, take, ct);
+
+        return new LeaderboardResponse(game.Value, entries.ToLeaderboardResponse());
+    }
+}

--- a/src/Lazy.Blog.Application/Arcade/GetLeaderboard/LeaderboardResponse.cs
+++ b/src/Lazy.Blog.Application/Arcade/GetLeaderboard/LeaderboardResponse.cs
@@ -1,0 +1,12 @@
+namespace Lazy.Application.Arcade.GetLeaderboard;
+
+public record LeaderboardResponse(
+    string Game,
+    IReadOnlyList<LeaderboardEntryResponse> Entries);
+
+public record LeaderboardEntryResponse(
+    int Rank,
+    string UserName,
+    string? AvatarUrl,
+    int BestScore,
+    int GamesPlayed);

--- a/src/Lazy.Blog.Application/Arcade/GetMyArcadeStats/ArcadeStatsResponse.cs
+++ b/src/Lazy.Blog.Application/Arcade/GetMyArcadeStats/ArcadeStatsResponse.cs
@@ -1,0 +1,7 @@
+namespace Lazy.Application.Arcade.GetMyArcadeStats;
+
+public record ArcadeStatsResponse(
+    string Game,
+    int BestScore,
+    int GamesPlayed,
+    int? Rank);

--- a/src/Lazy.Blog.Application/Arcade/GetMyArcadeStats/GetMyArcadeStatsQuery.cs
+++ b/src/Lazy.Blog.Application/Arcade/GetMyArcadeStats/GetMyArcadeStatsQuery.cs
@@ -1,0 +1,5 @@
+using Lazy.Application.Abstractions.Messaging;
+
+namespace Lazy.Application.Arcade.GetMyArcadeStats;
+
+public record GetMyArcadeStatsQuery(string Game) : IQuery<ArcadeStatsResponse>;

--- a/src/Lazy.Blog.Application/Arcade/GetMyArcadeStats/GetMyArcadeStatsQueryHandler.cs
+++ b/src/Lazy.Blog.Application/Arcade/GetMyArcadeStats/GetMyArcadeStatsQueryHandler.cs
@@ -1,0 +1,32 @@
+using Lazy.Application.Abstractions.Authorization;
+using Lazy.Application.Abstractions.Messaging;
+using Lazy.Application.Arcade.Extensions;
+using Lazy.Domain.Repositories;
+using Lazy.Domain.Shared;
+using Lazy.Domain.ValueObjects.Arcade;
+
+namespace Lazy.Application.Arcade.GetMyArcadeStats;
+
+public class GetMyArcadeStatsQueryHandler(
+    IArcadeScoreRepository arcadeScoreRepository,
+    ICurrentUserContext currentUserContext)
+    : IQueryHandler<GetMyArcadeStatsQuery, ArcadeStatsResponse>
+{
+    public async Task<Result<ArcadeStatsResponse>> Handle(GetMyArcadeStatsQuery request, CancellationToken ct)
+    {
+        Result<GameKey> gameKeyResult = GameKey.Create(request.Game);
+
+        if (gameKeyResult.IsFailure)
+        {
+            return Result.Failure<ArcadeStatsResponse>(gameKeyResult.Error);
+        }
+
+        GameKey game = gameKeyResult.Value;
+
+        Guid currentUserId = currentUserContext.GetCurrentUserId();
+
+        ArcadeUserStats stats = await arcadeScoreRepository.GetUserStatsAsync(currentUserId, game, ct);
+
+        return stats.ToArcadeStatsResponse(game);
+    }
+}

--- a/src/Lazy.Blog.Application/Arcade/SubmitScore/SubmitScoreCommand.cs
+++ b/src/Lazy.Blog.Application/Arcade/SubmitScore/SubmitScoreCommand.cs
@@ -1,0 +1,6 @@
+using Lazy.Application.Abstractions.Messaging;
+using Lazy.Application.Arcade.GetMyArcadeStats;
+
+namespace Lazy.Application.Arcade.SubmitScore;
+
+public record SubmitScoreCommand(string Game, int Score) : ICommand<ArcadeStatsResponse>;

--- a/src/Lazy.Blog.Application/Arcade/SubmitScore/SubmitScoreCommandHandler.cs
+++ b/src/Lazy.Blog.Application/Arcade/SubmitScore/SubmitScoreCommandHandler.cs
@@ -1,0 +1,49 @@
+using Lazy.Application.Abstractions.Authorization;
+using Lazy.Application.Abstractions.Messaging;
+using Lazy.Application.Arcade.Extensions;
+using Lazy.Application.Arcade.GetMyArcadeStats;
+using Lazy.Domain.Entities;
+using Lazy.Domain.Errors;
+using Lazy.Domain.Repositories;
+using Lazy.Domain.Shared;
+using Lazy.Domain.ValueObjects.Arcade;
+
+namespace Lazy.Application.Arcade.SubmitScore;
+
+public class SubmitScoreCommandHandler(
+    IArcadeScoreRepository arcadeScoreRepository,
+    ICurrentUserContext currentUserContext,
+    IUserRepository userRepository,
+    IUnitOfWork unitOfWork)
+    : ICommandHandler<SubmitScoreCommand, ArcadeStatsResponse>
+{
+    public async Task<Result<ArcadeStatsResponse>> Handle(SubmitScoreCommand request, CancellationToken ct)
+    {
+        Result<GameKey> gameKeyResult = GameKey.Create(request.Game);
+
+        if (gameKeyResult.IsFailure)
+        {
+            return Result.Failure<ArcadeStatsResponse>(gameKeyResult.Error);
+        }
+
+        Guid currentUserId = currentUserContext.GetCurrentUserId();
+
+        User? user = await userRepository.GetByIdAsync(currentUserId, ct);
+
+        if (user is null)
+        {
+            return Result.Failure<ArcadeStatsResponse>(DomainErrors.User.NotFound(currentUserId));
+        }
+
+        GameKey game = gameKeyResult.Value;
+
+        ArcadeScore score = ArcadeScore.Create(currentUserId, game, request.Score);
+        arcadeScoreRepository.Add(score);
+
+        await unitOfWork.SaveChangesAsync(ct);
+
+        ArcadeUserStats stats = await arcadeScoreRepository.GetUserStatsAsync(currentUserId, game, ct);
+
+        return stats.ToArcadeStatsResponse(game);
+    }
+}

--- a/src/Lazy.Blog.Application/Arcade/SubmitScore/SubmitScoreCommandValidator.cs
+++ b/src/Lazy.Blog.Application/Arcade/SubmitScore/SubmitScoreCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using Lazy.Domain.ValueObjects.Arcade;
+
+namespace Lazy.Application.Arcade.SubmitScore;
+
+public class SubmitScoreCommandValidator : AbstractValidator<SubmitScoreCommand>
+{
+    private const int MaxScore = 1_000_000;
+
+    public SubmitScoreCommandValidator()
+    {
+        RuleFor(x => x.Game).NotEmpty().MaximumLength(GameKey.MaxLength);
+
+        RuleFor(x => x.Score).InclusiveBetween(0, MaxScore);
+    }
+}

--- a/src/Lazy.Blog.Domain/Entities/ArcadeScore.cs
+++ b/src/Lazy.Blog.Domain/Entities/ArcadeScore.cs
@@ -1,0 +1,34 @@
+using Lazy.Domain.Primitives;
+using Lazy.Domain.ValueObjects.Arcade;
+
+namespace Lazy.Domain.Entities;
+
+public sealed class ArcadeScore : Entity, IAuditableEntity
+{
+    private ArcadeScore(Guid id, Guid userId, GameKey game, int score)
+        : base(id)
+    {
+        UserId = userId;
+        Game = game;
+        Score = score;
+    }
+
+    private ArcadeScore()
+    {
+    }
+
+    public Guid UserId { get; private set; }
+
+    public User User { get; private set; } = null!;
+
+    public GameKey Game { get; private set; } = null!;
+
+    public int Score { get; private set; }
+
+    public DateTime CreatedOnUtc { get; set; }
+
+    public DateTime? UpdatedOnUtc { get; set; }
+
+    public static ArcadeScore Create(Guid userId, GameKey game, int score) =>
+        new(Guid.NewGuid(), userId, game, score);
+}

--- a/src/Lazy.Blog.Domain/Errors/DomainErrors.cs
+++ b/src/Lazy.Blog.Domain/Errors/DomainErrors.cs
@@ -262,4 +262,15 @@ public static class DomainErrors
             "MediaItem.UnauthorizedAccess",
             "Media item access unauthorized");
     }
+
+    public static class ArcadeScore
+    {
+        public static readonly Error GameKeyEmpty = new(
+            "ArcadeScore.GameKeyEmpty",
+            "The game key is required");
+
+        public static readonly Error GameKeyTooLong = new(
+            "ArcadeScore.GameKeyTooLong",
+            "The game key is too long");
+    }
 }

--- a/src/Lazy.Blog.Domain/Repositories/ArcadeUserStats.cs
+++ b/src/Lazy.Blog.Domain/Repositories/ArcadeUserStats.cs
@@ -1,0 +1,3 @@
+namespace Lazy.Domain.Repositories;
+
+public readonly record struct ArcadeUserStats(int BestScore, int GamesPlayed, int? Rank);

--- a/src/Lazy.Blog.Domain/Repositories/IArcadeScoreRepository.cs
+++ b/src/Lazy.Blog.Domain/Repositories/IArcadeScoreRepository.cs
@@ -1,0 +1,13 @@
+using Lazy.Domain.Entities;
+using Lazy.Domain.ValueObjects.Arcade;
+
+namespace Lazy.Domain.Repositories;
+
+public interface IArcadeScoreRepository
+{
+    void Add(ArcadeScore score);
+
+    Task<IReadOnlyList<LeaderboardEntry>> GetLeaderboardAsync(GameKey game, int take, CancellationToken ct);
+
+    Task<ArcadeUserStats> GetUserStatsAsync(Guid userId, GameKey game, CancellationToken ct);
+}

--- a/src/Lazy.Blog.Domain/Repositories/LeaderboardEntry.cs
+++ b/src/Lazy.Blog.Domain/Repositories/LeaderboardEntry.cs
@@ -1,0 +1,8 @@
+namespace Lazy.Domain.Repositories;
+
+public sealed record LeaderboardEntry(
+    Guid UserId,
+    string UserName,
+    string? AvatarUrl,
+    int BestScore,
+    int GamesPlayed);

--- a/src/Lazy.Blog.Domain/ValueObjects/Arcade/GameKey.cs
+++ b/src/Lazy.Blog.Domain/ValueObjects/Arcade/GameKey.cs
@@ -1,0 +1,35 @@
+using Lazy.Domain.Errors;
+using Lazy.Domain.Primitives;
+using Lazy.Domain.Shared;
+
+namespace Lazy.Domain.ValueObjects.Arcade;
+
+public class GameKey : ValueObject
+{
+    public const int MaxLength = 50;
+
+    public static readonly GameKey Snake = new("snake");
+
+    private GameKey()
+    {
+    }
+
+    private GameKey(string value) => Value = value;
+
+    public string Value { get; private set; } = null!;
+
+    public static Result<GameKey> Create(string gameKey) =>
+        Result.Create(gameKey)
+            .Ensure(
+                g => !string.IsNullOrWhiteSpace(g),
+                DomainErrors.ArcadeScore.GameKeyEmpty)
+            .Ensure(
+                g => g.Length <= MaxLength,
+                DomainErrors.ArcadeScore.GameKeyTooLong)
+            .Map(g => new GameKey(g.Trim().ToLowerInvariant()));
+
+    public override IEnumerable<object> GetAtomicValues()
+    {
+        yield return Value;
+    }
+}

--- a/src/Lazy.Blog.Persistence/Configurations/ArcadeScoreConfiguration.cs
+++ b/src/Lazy.Blog.Persistence/Configurations/ArcadeScoreConfiguration.cs
@@ -1,0 +1,31 @@
+using Lazy.Domain.Entities;
+using Lazy.Domain.ValueObjects.Arcade;
+using Lazy.Persistence.Constants;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Lazy.Persistence.Configurations;
+
+internal sealed class ArcadeScoreConfiguration : IEntityTypeConfiguration<ArcadeScore>
+{
+    public void Configure(EntityTypeBuilder<ArcadeScore> builder)
+    {
+        builder.ToTable(TableNames.ArcadeScores);
+
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.Game)
+            .HasConversion(g => g.Value, v => GameKey.Create(v).Value)
+            .HasMaxLength(GameKey.MaxLength);
+
+        builder.Property(s => s.Score);
+
+        builder
+            .HasOne(s => s.User)
+            .WithMany()
+            .HasForeignKey(s => s.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(s => new { s.Game, s.UserId, s.Score });
+    }
+}

--- a/src/Lazy.Blog.Persistence/Constants/TableNames.cs
+++ b/src/Lazy.Blog.Persistence/Constants/TableNames.cs
@@ -14,4 +14,5 @@ public class TableNames
     internal const string Tags = nameof(Tags);
     internal const string PostVotes = nameof(PostVotes);
     internal const string MediaItems = nameof(MediaItems);
+    internal const string ArcadeScores = nameof(ArcadeScores);
 }

--- a/src/Lazy.Blog.Persistence/Migrations/20260625095612_AddArcadeScores.Designer.cs
+++ b/src/Lazy.Blog.Persistence/Migrations/20260625095612_AddArcadeScores.Designer.cs
@@ -4,6 +4,7 @@ using Lazy.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Lazy.Persistence.Migrations
 {
     [DbContext(typeof(LazyBlogDbContext))]
-    partial class LazyBlogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260625095612_AddArcadeScores")]
+    partial class AddArcadeScores
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Lazy.Blog.Persistence/Migrations/20260625095612_AddArcadeScores.cs
+++ b/src/Lazy.Blog.Persistence/Migrations/20260625095612_AddArcadeScores.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Lazy.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddArcadeScores : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ArcadeScores",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Game = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Score = table.Column<int>(type: "int", nullable: false),
+                    CreatedOnUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedOnUtc = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ArcadeScores", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ArcadeScores_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ArcadeScores_Game_UserId_Score",
+                table: "ArcadeScores",
+                columns: new[] { "Game", "UserId", "Score" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ArcadeScores_UserId",
+                table: "ArcadeScores",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ArcadeScores");
+        }
+    }
+}

--- a/src/Lazy.Blog.Persistence/Repositories/ArcadeScoreRepository.cs
+++ b/src/Lazy.Blog.Persistence/Repositories/ArcadeScoreRepository.cs
@@ -1,0 +1,72 @@
+using Lazy.Domain.Entities;
+using Lazy.Domain.Repositories;
+using Lazy.Domain.ValueObjects.Arcade;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lazy.Persistence.Repositories;
+
+public class ArcadeScoreRepository(
+    LazyBlogDbContext dbContext,
+    IDbContextFactory<LazyBlogDbContext> dbContextFactory) : IArcadeScoreRepository
+{
+    public void Add(ArcadeScore score) =>
+        dbContext.Set<ArcadeScore>().Add(score);
+
+    public async Task<IReadOnlyList<LeaderboardEntry>> GetLeaderboardAsync(GameKey game, int take, CancellationToken ct)
+    {
+        await using var ctx = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var leaderboard = await ctx.Set<ArcadeScore>()
+            .AsNoTracking()
+            .Where(s => s.Game == game)
+            .GroupBy(s => s.UserId)
+            .Select(g => new
+            {
+                UserId = g.Key,
+                BestScore = g.Max(s => s.Score),
+                GamesPlayed = g.Count()
+            })
+            .OrderByDescending(g => g.BestScore)
+            .ThenBy(g => g.GamesPlayed)
+            .Take(take)
+            .Join(
+                ctx.Set<User>().AsNoTracking(),
+                g => g.UserId,
+                u => u.Id,
+                (g, u) => new LeaderboardEntry(
+                    u.Id,
+                    u.UserName!,
+                    u.Avatar != null ? u.Avatar.Url : null,
+                    g.BestScore,
+                    g.GamesPlayed))
+            .ToListAsync(ct);
+
+        return leaderboard;
+    }
+
+    public async Task<ArcadeUserStats> GetUserStatsAsync(Guid userId, GameKey game, CancellationToken ct)
+    {
+        await using var ctx = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var stats = await ctx.Set<ArcadeScore>()
+            .AsNoTracking()
+            .Where(s => s.Game == game && s.UserId == userId)
+            .GroupBy(s => s.UserId)
+            .Select(g => new { BestScore = g.Max(s => s.Score), GamesPlayed = g.Count() })
+            .FirstOrDefaultAsync(ct);
+
+        if (stats is null)
+        {
+            return new ArcadeUserStats(0, 0, null);
+        }
+
+        int playersAhead = await ctx.Set<ArcadeScore>()
+            .AsNoTracking()
+            .Where(s => s.Game == game)
+            .GroupBy(s => s.UserId)
+            .Select(g => g.Max(s => s.Score))
+            .CountAsync(best => best > stats.BestScore, ct);
+
+        return new ArcadeUserStats(stats.BestScore, stats.GamesPlayed, playersAhead + 1);
+    }
+}

--- a/src/Lazy.Blog.Presentation/Contracts/Arcade/SubmitScoreRequest.cs
+++ b/src/Lazy.Blog.Presentation/Contracts/Arcade/SubmitScoreRequest.cs
@@ -1,0 +1,7 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Lazy.Presentation.Contracts.Arcade;
+
+public record SubmitScoreRequest(
+    [Required] int Score,
+    string? Game = null);

--- a/src/Lazy.Blog.Presentation/Controllers/ArcadeController.cs
+++ b/src/Lazy.Blog.Presentation/Controllers/ArcadeController.cs
@@ -36,10 +36,10 @@ public class ArcadeController : BaseJwtController
         return response.IsSuccess ? Ok(response.Value) : HandleFailure(response);
     }
 
-    [AllowAnonymous]
     [HttpGet("leaderboard", Name = nameof(GetLeaderboard))]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(LeaderboardResponse))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetLeaderboard(
         CancellationToken ct,
         string? game = null,

--- a/src/Lazy.Blog.Presentation/Controllers/ArcadeController.cs
+++ b/src/Lazy.Blog.Presentation/Controllers/ArcadeController.cs
@@ -1,0 +1,68 @@
+using Lazy.Application.Arcade.GetLeaderboard;
+using Lazy.Application.Arcade.GetMyArcadeStats;
+using Lazy.Application.Arcade.SubmitScore;
+using Lazy.Domain.Shared;
+using Lazy.Domain.ValueObjects.Arcade;
+using Lazy.Presentation.Abstractions;
+using Lazy.Presentation.Contracts.Arcade;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Lazy.Presentation.Controllers;
+
+[Authorize]
+[Route("api/arcade")]
+public class ArcadeController : BaseJwtController
+{
+    public ArcadeController(ISender sender, ILogger<ArcadeController> logger)
+        : base(sender, logger)
+    {
+    }
+
+    [HttpPost("scores", Name = nameof(SubmitScore))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ArcadeStatsResponse))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> SubmitScore(
+        [FromBody] SubmitScoreRequest request,
+        CancellationToken ct)
+    {
+        var command = new SubmitScoreCommand(request.Game ?? GameKey.Snake.Value, request.Score);
+
+        Result<ArcadeStatsResponse> response = await Sender.Send(command, ct);
+
+        return response.IsSuccess ? Ok(response.Value) : HandleFailure(response);
+    }
+
+    [AllowAnonymous]
+    [HttpGet("leaderboard", Name = nameof(GetLeaderboard))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(LeaderboardResponse))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetLeaderboard(
+        CancellationToken ct,
+        string? game = null,
+        int take = 10)
+    {
+        var query = new GetLeaderboardQuery(game ?? GameKey.Snake.Value, take);
+
+        Result<LeaderboardResponse> response = await Sender.Send(query, ct);
+
+        return response.IsSuccess ? Ok(response.Value) : HandleFailure(response);
+    }
+
+    [HttpGet("scores/me", Name = nameof(GetMyArcadeStats))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ArcadeStatsResponse))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetMyArcadeStats(
+        CancellationToken ct,
+        string? game = null)
+    {
+        var query = new GetMyArcadeStatsQuery(game ?? GameKey.Snake.Value);
+
+        Result<ArcadeStatsResponse> response = await Sender.Send(query, ct);
+
+        return response.IsSuccess ? Ok(response.Value) : HandleFailure(response);
+    }
+}


### PR DESCRIPTION
## Summary
  Backend for the in-app Arcade (Snake first). Adds an `ArcadeScore` aggregate (one row per run), a best-per-user
  leaderboard, and per-user stats. Pure addition — no existing endpoint, table, or contract changes.

  ## Endpoints (all under `api/arcade`, all require auth / JWT)
  | Verb | Route | Purpose |
  | --- | --- | --- |
  | POST | `/api/arcade/scores` | Submit a run's score; returns the caller's updated stats |
  | GET | `/api/arcade/leaderboard` | Top-N best-per-user for a game |
  | GET | `/api/arcade/scores/me` | Caller's best / games played / rank |

  All default `game` to `"snake"`. 

  ### DTO shapes (for the FE OpenAPI client)
  - `SubmitScoreRequest`: `{ "score": 1234, "game": "snake" }` (`game` optional)
  - `ArcadeStatsResponse`: `{ "game", "bestScore", "gamesPlayed", "rank" }` (`rank` is `int?`, `null` if no runs)
  - `LeaderboardResponse`: `{ "game", "entries": [{ "rank", "userName", "avatarUrl", "bestScore", "gamesPlayed" }]
  }` — `take` defaults 10, clamped `[1, 100]`; `avatarUrl` nullable.
  
  ## Design / semantics
  - Best-per-user leaderboard = a single grouped query (no N+1); tie-break = fewest games played.
  - `rank` = players strictly ahead + 1 (standard competition rank); `null` when the caller has no runs.
  - `GameKey` normalises (trim + lowercase), max 50 chars.
  - Reads fan out over `IDbContextFactory` + `AsNoTracking`; repo auto-registers via Scrutor.
  - **Leaderboard is members-only** (owner decision).

  ## Migration
  `AddArcadeScores` creates the `ArcadeScores` table only (FK → Users cascade, composite index `Game/UserId/Score`).
  No model drift.
  
  dotnet ef database update -p src/Lazy.Blog.Persistence -s src/Lazy.Blog.Api

  ## Open question (not blocking)
  - **Store-every-run vs best-only**: we persist one row per run (enables games-played + future history /
  anti-cheat) and aggregate on read. Could be a single upsert per `(user, game)` if only personal best matters.

  ## Verification
  - `dotnet build` → 0 errors (only pre-existing / unrelated warnings).
  - `ef has-pending-model-changes` → no drift. No test project in the solution.